### PR TITLE
feat: use OED authentication

### DIFF
--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -7,7 +7,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
-    traefik.ingress.kubernetes.io/router.middlewares: "alphasynthesis-cleandb-prod-domain-redirect@kubernetescrd"
+    traefik.ingress.kubernetes.io/router.middlewares: "openenzymedb-oed-cors-header@kubernetescrd,openenzymedb-oed-redirect-to-login@kubernetescrd,openenzymedb-oed-private-auth@kubernetescrd,alphasynthesis-cleandb-prod-domain-redirect@kubernetescrd"
 
 controller:
   image: moleculemaker/cleandb-frontend:main

--- a/chart/values.prod.yaml
+++ b/chart/values.prod.yaml
@@ -1,7 +1,7 @@
 ingress:
-  hostname: cleandb.platform.moleculemaker.org
+  hostname: cleandb.openenzymedb.platform.moleculemaker.org
   extraHosts:
-  - cleandb.frontend.mmli1.ncsa.illinois.edu
+  - cleandb.frontend.openenzymedb.mmli1.ncsa.illinois.edu
   tls: true
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
@@ -15,8 +15,8 @@ controller:
 config:
   hostname: "https://mmli.fastapi.mmli1.ncsa.illinois.edu"
   basePath: ""
-  signInUrl: "https://auth.platform.moleculemaker.org/oauth2/start?rd=https%3A%2F%2Fcleandb.platform.moleculemaker.org%2Fconfiguration"
-  signOutUrl: "https://auth.platform.moleculemaker.org/oauth2/sign_out?rd=https%3A%2F%2Fcleandb.platform.moleculemaker.org%2Fconfiguration"
+  signInUrl: "https://auth.platform.moleculemaker.org/oauth2/start?rd=https%3A%2F%2Fcleandb.openenzymedb.platform.moleculemaker.org%2Fconfiguration"
+  signOutUrl: "https://auth.platform.moleculemaker.org/oauth2/sign_out?rd=https%3A%2F%2Fcleandb.openenzymedb.platform.moleculemaker.org%2Fconfiguration"
   userInfoUrl: "https://auth.platform.moleculemaker.org/oauth2/userinfo"
   frontendOnly: "false"
 
@@ -28,6 +28,6 @@ extraDeploy:
     namespace: alphasynthesis
   spec:
     redirectRegex:
-      regex: "^https://cleandb.frontend.mmli1.ncsa.illinois.edu/(.*)"
-      replacement: "https://cleandb.platform.moleculemaker.org/${1}"
+      regex: "^https://cleandb.frontend.openenzymedb.mmli1.ncsa.illinois.edu/(.*)"
+      replacement: "https://cleandb.openenzymedb.platform.moleculemaker.org/${1}"
       permanent: true

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -5,6 +5,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/tls-acme: "true"
     traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: "openenzymedb-oed-staging-redirect-to-login@kubernetescrd,openenzymedb-oed-staging-private-auth@kubernetescrd"
 
 controller:
   image: moleculemaker/cleandb-frontend:staging

--- a/chart/values.staging.yaml
+++ b/chart/values.staging.yaml
@@ -1,5 +1,5 @@
 ingress:
-  hostname: cleandb.frontend.staging.mmli1.ncsa.illinois.edu
+  hostname: cleandb.frontend.staging.openenzymedb.mmli1.ncsa.illinois.edu
   tls: true
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
@@ -10,9 +10,9 @@ controller:
   image: moleculemaker/cleandb-frontend:staging
 
 config:
-  hostname: "https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu"
+  hostname: "https://mmli.fastapi.staging.openenzymedb.mmli1.ncsa.illinois.edu"
   basePath: ""
-  signInUrl: "https://mmli1.ncsa.illinois.edu/oauth2/start?rd=https%3A%2F%2Fcleandb.frontend.staging.mmli1.ncsa.illinois.edu%2Fconfiguration"
-  signOutUrl: "https://mmli1.ncsa.illinois.edu/oauth2/sign_out?rd=https%3A%2F%2Fcleandb.frontend.staging.mmli1.ncsa.illinois.edu%2Fconfiguration"
+  signInUrl: "https://mmli1.ncsa.illinois.edu/oauth2/start?rd=https%3A%2F%2Fcleandb.frontend.staging.openenzymedb.mmli1.ncsa.illinois.edu%2Fconfiguration"
+  signOutUrl: "https://mmli1.ncsa.illinois.edu/oauth2/sign_out?rd=https%3A%2F%2Fcleandb.frontend.staging.openenzymedb.mmli1.ncsa.illinois.edu%2Fconfiguration"
   userInfoUrl: "https://mmli1.ncsa.illinois.edu/oauth2/userinfo"
   frontendOnly: "false"


### PR DESCRIPTION
## Problem
CLEANDB-frontend prototype is currently publicly accessible

We would like this to be behind the same (temporary) auth wall that is currently used by OpenEnzymeDB

## Approach
* feat: adjust URL patterns to share cookies between CLEANDB and OED prototypes
* feat: add private-auth/errors middleware to redirect without auth
 
### TODOs:
* add middleware to CLEANDB-api

## How to Test
NOT CURRENTLY DEPLOYED

Staging:
1. Close all incognito windows, and open a fresh incognito window
2. Navigate to CLEANDB staging: https://cleandb.staging.openenzymedb.mmli1.ncsa.illinois.edu
    * You should be prompted to login in with Keycloak
3. Log into Keycloak using CILogon or username/password
    * If your account is in the correct Keycloak group (`openenzymedb`), you should be routed to the CLEANDB frontend
    * If your account is not in the correct Keycloak group (`openenzymedb`), you should be shown a 403: Forbidden error page

Production:
1. Close all incognito windows, and open a fresh incognito window
2. Navigate to CLEANDB prod: https://cleandb.openenzymedb.platform.moleculemaker.org
    * You should be prompted to login in with Keycloak
3. Log into Keycloak using CILogon or username/password
    * If your account is in the correct Keycloak group (`openenzymedb`), you should be routed to the CLEANDB frontend
    * If your account is not in the correct Keycloak group (`openenzymedb`), you should be shown a 403: Forbidden error page