### PR TITLE
replaced reaction scheme arrow

### DIFF
--- a/src/app/components/reaction-schema/reaction-schema.component.html
+++ b/src/app/components/reaction-schema/reaction-schema.component.html
@@ -10,7 +10,7 @@
     } 
   }"></ng-container>
   }
-  <span>&nbsp;-&gt;;&nbsp;</span>
+  <span>&nbsp;&rarr;&nbsp;</span>
   @for (product of reactionSchema.products; track product; let index = $index) {
     @if (index !== 0) {
       <span>&nbsp;+&nbsp;</span>


### PR DESCRIPTION
This fixes the stray semicolon seen in the screenshot below. (For a live example, see any reaction scheme at https://cleandb.platform.moleculemaker.org/database-search.)

![image](https://github.com/user-attachments/assets/d51b5c6f-4e00-4462-8066-d46e452b79cd)
