### PR TITLE
fix: MEP heatmap interactivity and tooltip flicker (#41)

### DIFF
--- a/src/app/components/heatmap/heatmap.component.html
+++ b/src/app/components/heatmap/heatmap.component.html
@@ -89,15 +89,15 @@
 <p-overlayPanel
   #cellTooltip
   [dismissable]="true"
-  [showCloseIcon]="true"
+  [showCloseIcon]="false"
   styleClass="rounded-xl shadow-2xl max-w-xs p-2 bg-[#343A40] text-white border border-white/10"
-  (onHide)="onCellMouseLeave()"
+  (onHide)="onTooltipHidden()"
 >
   <ng-container *ngIf="tooltipContext as tooltip">
     <span class="text-base font-semibold tracking-tight">{{ tooltip.displayLabel }}</span>
     <div class="h-px bg-white/20 my-1"></div>
 
-    <div class="flex items-center justify-between text-sm">
+    <div class="flex items-center justify-between gap-4 text-sm">
       <span class="uppercase text-xs tracking-[0.08em] text-white/70">LLR</span>
       <div class="flex items-center gap-2">
         <span class="inline-block h-2.5 w-2.5 rounded-full shadow-[0_0_0_2px_rgba(255,255,255,0.2)]" [style.backgroundColor]="tooltip.accentColor"></span>
@@ -105,7 +105,7 @@
       </div>
     </div>
 
-    <div class="flex items-center justify-between text-sm">
+    <div class="flex items-center justify-between gap-4 text-sm">
       <span class="uppercase text-xs tracking-[0.08em] text-white/70">Predicted Effect</span>
       <div class="flex items-center gap-2 font-semibold" [ngClass]="tooltip.accentClass">
         <i class="pi text-sm" [ngClass]="tooltip.arrowIcon"></i>

--- a/src/app/components/heatmap/heatmap.component.ts
+++ b/src/app/components/heatmap/heatmap.component.ts
@@ -111,6 +111,7 @@ export class HeatmapComponent implements OnChanges, OnDestroy {
     maximumFractionDigits: 2,
   });
   private tooltipTarget: HTMLElement | null = null;
+  private hideTooltipTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private selectedCellSet = new Set<string>();
   private mutedCellSet = new Set<string>();
 
@@ -194,6 +195,7 @@ export class HeatmapComponent implements OnChanges, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.cancelHideTooltip();
     this.subscriptions.forEach((subscription) => subscription.unsubscribe());
   }
 
@@ -355,6 +357,9 @@ export class HeatmapComponent implements OnChanges, OnDestroy {
       return;
     }
 
+    // Cancel any pending hide; moving to an adjacent cell should keep the tooltip
+    this.cancelHideTooltip();
+
     // Restore previous hovered cell to its base state
     if (this.manualSelectedCell && this.manualSelectedCell !== interactable) {
       this.manualSelectedCell.state = this.getBaseCellState(this.manualSelectedCell);
@@ -372,15 +377,39 @@ export class HeatmapComponent implements OnChanges, OnDestroy {
   }
 
   onCellMouseLeave(): void {
+    // Debounce hide so rapid moves to adjacent cells don't trigger a hide/show flicker
+    this.cancelHideTooltip();
+    this.hideTooltipTimeoutId = setTimeout(() => {
+      this.hideTooltipTimeoutId = null;
+      if (this.manualSelectedCell) {
+        this.manualSelectedCell.state = this.getBaseCellState(this.manualSelectedCell);
+        this.manualSelectedCell = null;
+      }
+      this.tooltipContext = null;
+      this.tooltipTarget = null;
+      if (this.cellTooltip?.overlayVisible) {
+        this.cellTooltip.hide();
+      }
+      this.cdr.markForCheck();
+    }, 80);
+  }
+
+  private cancelHideTooltip(): void {
+    if (this.hideTooltipTimeoutId !== null) {
+      clearTimeout(this.hideTooltipTimeoutId);
+      this.hideTooltipTimeoutId = null;
+    }
+  }
+
+  onTooltipHidden(): void {
+    // Reset transient hover state when the tooltip is dismissed (e.g. outside click)
     if (this.manualSelectedCell) {
       this.manualSelectedCell.state = this.getBaseCellState(this.manualSelectedCell);
       this.manualSelectedCell = null;
     }
     this.tooltipContext = null;
     this.tooltipTarget = null;
-    if (this.cellTooltip?.overlayVisible) {
-      this.cellTooltip.hide();
-    }
+    this.cdr.markForCheck();
   }
 
   /* ---------------------------------- Utils --------------------------------- */
@@ -533,17 +562,11 @@ export class HeatmapComponent implements OnChanges, OnDestroy {
       return;
     }
 
-    const showOverlay = () => {
-      const overlayEvent = this.resolveOverlayEvent(event, targetElement);
-      this.cellTooltip!.show(overlayEvent, targetElement);
-    };
-
-    if (this.cellTooltip.overlayVisible) {
-      this.cellTooltip.hide();
-      setTimeout(showOverlay);
-    } else {
-      showOverlay();
-    }
+    const overlayEvent = this.resolveOverlayEvent(event, targetElement);
+    // PrimeNG's show() handles the already-visible case by retargeting and re-aligning,
+    // so there is no need to hide() first — doing so causes a flicker where the close
+    // icon briefly renders during the hide animation.
+    this.cellTooltip.show(overlayEvent, targetElement);
   }
 
   private getBaseCellState(interactable: Interactable): InteractableState {

--- a/src/app/pages/effect-prediction-result/effect-prediction-result.component.html
+++ b/src/app/pages/effect-prediction-result/effect-prediction-result.component.html
@@ -46,6 +46,15 @@
     <p-panel>
       <ng-template pTemplate="header">
         <h6 class="grow">Results</h6>
+        <button
+          type="button"
+          class="flex items-center gap-2 bg-transparent border-none text-primary cursor-pointer p-2 text-sm font-semibold hover:underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
+          [disabled]="selectedPositions.length === 0 && mutedPositions.length === 0"
+          (click)="clearAll()"
+        >
+          <i class="pi pi-times-circle"></i>
+          Clear All
+        </button>
       </ng-template>
       <ng-template pTemplate="content">
         <div class="flex flex-col gap-6 p-6">

--- a/src/app/pages/effect-prediction-result/effect-prediction-result.component.ts
+++ b/src/app/pages/effect-prediction-result/effect-prediction-result.component.ts
@@ -75,7 +75,6 @@ export class EffectPredictionResultComponent implements OnDestroy {
   jobId: string                             = this.route.snapshot.paramMap.get("id") || "precomputed";
   jobInfo: any                              = {};
   jobType: JobType                          = JobType.CleandbMepesm;
-  previousSelectedPositions: number[]       = [];
   mutedCells: HeatmapCellLocations          = [];
   mutedPositions: number[]                  = [];
   numColumns                                = 20;
@@ -181,15 +180,16 @@ export class EffectPredictionResultComponent implements OnDestroy {
   onSelectedPositionsChange(newPositions: number[]): void {
     this.selectedCells = this.generateCellsFromPositions(newPositions);
     if (newPositions.length > 0) {
-      const oldPositionSet = new Set(this.previousSelectedPositions);
+      const oldPositionSet = new Set(this.selectedPositions);
       const newPositionSet = new Set(newPositions);
       //@ts-ignore
       const diff: number[] = Array.from(newPositionSet.difference(oldPositionSet));
-      const minPosition = Math.min(...diff);
-      this.heatmap.scrollToCol(minPosition);
-      this.scrollTableToPosition(minPosition + 1); // table uses 1-based positions
+      if (diff.length > 0) {
+        const minPosition = Math.min(...diff);
+        this.heatmap.scrollToCol(minPosition);
+        this.scrollTableToPosition(minPosition + 1); // table uses 1-based positions
+      }
     }
-    this.previousSelectedPositions = [...this.selectedPositions];
     this.selectedPositions = newPositions;
     this.syncViewerSelections();
   }
@@ -270,6 +270,14 @@ export class EffectPredictionResultComponent implements OnDestroy {
     link.remove();
   }
 
+  clearAll(): void {
+    this.selectedPositions = [];
+    this.selectedCells = [];
+    this.mutedPositions = [];
+    this.mutedCells = [];
+    this.syncViewerSelections();
+  }
+
   /* ------------------------------ Utils ------------------------------ */
   togglePosition(position: number): void {
     const idx = this.selectedPositions.indexOf(position);
@@ -279,7 +287,6 @@ export class EffectPredictionResultComponent implements OnDestroy {
     } else {
       newPositions = [...this.selectedPositions, position];
     }
-    this.previousSelectedPositions = [...this.selectedPositions];
     this.selectedPositions = newPositions;
     this.selectedCells = this.generateCellsFromPositions(newPositions);
     this.syncViewerSelections();


### PR DESCRIPTION
Fixes #41.

## Summary
- **Scroll on every click**: diff selected positions against current state instead of a stale `previousSelectedPositions` snapshot. Previously the snapshot was updated from the old `selectedPositions` before it got the new value, so it always lagged one click behind — the sequence-viewer's 2nd click would compute `Math.min(click1, click2)` and scroll to click 1's position. Now the table/heatmap auto-scroll on every click.
- **Tooltip flicker fix**: drop the `hide()` + `setTimeout(show)` cycle in the heatmap `openTooltip` and just call PrimeNG's `OverlayPanel.show(event, target)` directly (it already retargets and re-aligns when already visible). The hide animation is what caused the brief close-icon / empty-box flash when moving between adjacent cells.
- **Cross-cell stability**: debounce `onCellMouseLeave` by 80 ms so the tooltip isn't torn down mid-transit between neighboring cells.
- **Design audit tweaks** (from @karneson-illinois's comment on the issue):
  - Remove the close icon from the heatmap hover tooltip (not needed on hover-only UI).
  - Add 16 px horizontal spacing between label and value in the tooltip.
  - Add a **Clear All** button to the Results panel header that resets sequence, heatmap, structure, and table selections.

## Test plan
- [ ] On `/effect-prediction/result/precomputed`, click a residue in the Sequence Viewer → heatmap/table scroll to that residue.
- [ ] Click a second residue far from the first → heatmap/table scroll immediately (no need to click a third).
- [ ] Click a third residue adjacent to the second → heatmap/table scroll to the third.
- [ ] Hover over a heatmap cell, slowly move to an adjacent cell → tooltip updates smoothly with no close-icon / empty-box flash.
- [ ] Hover down then left across adjacent cells → tooltip content keeps updating.
- [ ] Confirm no close icon renders on the heatmap hover tooltip.
- [ ] Confirm the label/value pairs (LLR, Predicted Effect) have visible horizontal spacing (16 px).
- [ ] With nothing selected, the **Clear All** button is disabled. After selecting any residue(s), it enables; clicking it clears the sequence viewer highlights, heatmap selection boxes, 3D viewer selections, and table scroll position.