### PR TITLE
Revise expanded search-result row layout to match Figma

### DIFF
--- a/src/app/components/kinetic-table/kinetic-table.component.html
+++ b/src/app/components/kinetic-table/kinetic-table.component.html
@@ -186,17 +186,17 @@
 
                       <!-- Right column -->
                       <div class="flex flex-col gap-2 flex-1 min-w-0">
-                        <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'Protein Name', value: row.protein }"></ng-container>
+                        <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'Protein Name', value: row.protein, valueClass: 'max-w-[60ch] ml-auto' }"></ng-container>
                         @if (row.function) {
                         <div class="flex items-start gap-4 py-px w-full">
                           <div class="text-[--text-color] leading-[21px] shrink-0 whitespace-nowrap">Function</div>
-                          <div class="flex-1 min-w-0 font-semibold text-[--text-color] text-right leading-[16.8px] [word-break:break-word]">{{ row.function }}</div>
+                          <div class="max-w-[60ch] ml-auto min-w-0 font-semibold text-[--text-color] text-right leading-[16.8px] [word-break:break-word]">{{ row.function }}</div>
                         </div>
                         }
                         @if (row.generic_names?.length) {
                         <div class="flex items-start gap-4 py-px w-full">
                           <div class="text-[--text-color] leading-[21px] shrink-0 whitespace-nowrap">Generic Names</div>
-                          <div class="flex-1 min-w-0 text-right text-[--text-color] leading-[21px] [word-break:break-word]">
+                          <div class="max-w-[60ch] ml-auto min-w-0 text-right text-[--text-color] leading-[21px] [word-break:break-word]">
                             @for (value of row.generic_names; track value) {
                             <span class="font-semibold">{{ value.name }}</span> (EC: {{ value.ec }})@if ($index !== row.generic_names.length - 1) {<span>,&nbsp;</span>}
                             }
@@ -247,11 +247,11 @@
   </div>
 </div>
 
-<ng-template #rowInfo let-label="label" let-value="value">
+<ng-template #rowInfo let-label="label" let-value="value" let-valueClass="valueClass">
 @if (value) {
   <div class="flex items-start gap-4 py-px w-full">
     <div class="text-[--text-color] leading-[21px] shrink-0 whitespace-nowrap">{{ label }}</div>
-    <div class="flex-1 min-w-0 font-semibold text-[--text-color] text-right leading-[21px] [word-break:break-word]">{{ value }}</div>
+    <div class="min-w-0 font-semibold text-[--text-color] text-right leading-[21px] [word-break:break-word]" [ngClass]="valueClass || 'flex-1'">{{ value }}</div>
   </div>
 }
 </ng-template>

--- a/src/app/components/kinetic-table/kinetic-table.component.html
+++ b/src/app/components/kinetic-table/kinetic-table.component.html
@@ -164,31 +164,44 @@
               <tr>
                 <td colspan="11" class="relative overflow-hidden no-scrollbar bg-[#F7FAFF] !p-2">
                   <div [@slideIn]
-                    class="rounded-md border border-[--surface-d] border-solid bg-white p-2 flex flex-col gap-2 w-full">
-                    <div class="flex gap-16 flex-wrap">
-                      <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'ID', value: row.id }"></ng-container>
-                      <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'Gene', value: row.gene_name }"></ng-container>
-                      <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'Protein Name', value: row.protein }"></ng-container>
-                      <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'NCBI Tax ID', value: row.ncbi_tax_id }"></ng-container>
-                      <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'EC Number (UniProt)', value: row.ec_uniprot ? row.ec_uniprot.join(', ') : '' }"></ng-container>
-                      <div class="flex flex-col gap-2">
-                        <div class="text-[--text-secondary-color]">Enzyme Sequence</div>
-                        <button class="flex items-center gap-1 text-[#64748B] font-semibold" title="Download Sequence" (click)="copySequence(row.sequence)">
-                          <i class="pi pi-copy"></i>
-                          <h6>Copy to Clipboard</h6>
-                        </button>
+                    class="rounded-md border border-[--surface-d] border-solid bg-white p-3 flex flex-col gap-3 w-full">
+                    <div class="flex gap-4 items-start w-full">
+                      <!-- Left column -->
+                      <div class="flex flex-col gap-2 w-[377px] shrink-0">
+                        <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'ID', value: row.id }"></ng-container>
+                        <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'Gene', value: row.gene_name }"></ng-container>
+                        <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'NCBI Tax ID', value: row.ncbi_tax_id }"></ng-container>
+                        <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'EC Number (UniProt)', value: row.ec_uniprot ? row.ec_uniprot.join(', ') : '' }"></ng-container>
+                        <div class="flex items-start justify-between gap-4 py-px">
+                          <div class="text-[--text-color] leading-[21px] shrink-0 whitespace-nowrap">Enzyme Sequence</div>
+                          <button class="flex items-center gap-1 text-[#64748B] font-bold" title="Copy Sequence" (click)="copySequence(row.sequence)">
+                            <i class="pi pi-copy"></i>
+                            <h6 class="leading-[17px]">Copy to Clipboard</h6>
+                          </button>
+                        </div>
                       </div>
-                    </div>
 
-                    <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'Enzyme Function', value: row.function }"></ng-container>
-                    <div class="flex flex-col gap-2">
-                      <div class="text-[--text-secondary-color]">Generic Names</div>
-                      <div>
-                        @for (value of row.generic_names; track value) {
-                            <span class="font-semibold">{{ value.name }}</span> (EC: {{ value.ec }})
-                            @if ($index !== row.generic_names.length - 1) {
-                              <span>,&nbsp;</span>
+                      <!-- Divider -->
+                      <div class="w-px self-stretch bg-[--surface-d] shrink-0"></div>
+
+                      <!-- Right column -->
+                      <div class="flex flex-col gap-2 flex-1 min-w-0">
+                        <ng-container *ngTemplateOutlet="rowInfo; context: { label: 'Protein Name', value: row.protein }"></ng-container>
+                        @if (row.function) {
+                        <div class="flex items-start gap-4 py-px w-full">
+                          <div class="text-[--text-color] leading-[21px] shrink-0 whitespace-nowrap">Function</div>
+                          <div class="flex-1 min-w-0 font-semibold text-[--text-color] text-right leading-[16.8px] [word-break:break-word]">{{ row.function }}</div>
+                        </div>
+                        }
+                        @if (row.generic_names?.length) {
+                        <div class="flex items-start gap-4 py-px w-full">
+                          <div class="text-[--text-color] leading-[21px] shrink-0 whitespace-nowrap">Generic Names</div>
+                          <div class="flex-1 min-w-0 text-right text-[--text-color] leading-[21px] [word-break:break-word]">
+                            @for (value of row.generic_names; track value) {
+                            <span class="font-semibold">{{ value.name }}</span> (EC: {{ value.ec }})@if ($index !== row.generic_names.length - 1) {<span>,&nbsp;</span>}
                             }
+                          </div>
+                        </div>
                         }
                       </div>
                     </div>
@@ -236,9 +249,9 @@
 
 <ng-template #rowInfo let-label="label" let-value="value">
 @if (value) {
-  <div class="flex flex-col gap-1" [class.opacity-25]="!value">
-    <div class="text-[--text-secondary-color]">{{ label }}</div>
-    <div class="font-semibold" [class.opacity-25]="!value">{{ value || 'N/A' }}</div>
+  <div class="flex items-start gap-4 py-px w-full">
+    <div class="text-[--text-color] leading-[21px] shrink-0 whitespace-nowrap">{{ label }}</div>
+    <div class="flex-1 min-w-0 font-semibold text-[--text-color] text-right leading-[21px] [word-break:break-word]">{{ value }}</div>
   </div>
 }
 </ng-template>


### PR DESCRIPTION
## Summary

Revises the layout of the **expanded row** in the database search results table to match the [Figma design](https://www.figma.com/design/QdFc9QdyWbwDFDhwybm2Xs/CLEAN-DB?node-id=1906-1299).

The expanded row's info area is restructured from a single wrapping row of stacked label-over-value blocks into a **two-column split with a vertical divider**:

- **Left column:** ID, Gene, NCBI Tax ID, EC Number (UniProt), Enzyme Sequence (with Copy-to-Clipboard button)
- **Right column:** Protein Name, Function, Generic Names

Each field is now an inline **label (left, regular) / value (right-aligned, semibold)** pair, using the theme `--text-color` (#495057) for both, differentiated by weight — matching the Figma tokens.

## Notes

- **Scope:** info/metadata area only. The reaction-schema tabs and viz area below are unchanged (they already matched the design).
- Function wraps to as many lines as needed (right-aligned); Generic Names stays a comma-separated inline list (name bold, `(EC:)` regular) — both per the Figma Dev Mode annotations.
- Missing values continue to hide their whole row (preserved behavior).
- Desktop-first, no stacking — consistent with the rest of the results page, which uses no responsive breakpoints.
- Function field relabeled from "Enzyme Function" → "Function", and Protein Name moved from the left group to the right column, per Figma.

## Testing

- `ng build --configuration development` completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
