### PR TITLE
chore: adjust API URL for prod to point at new user-friendly alias

### DIFF
--- a/chart/values.mmli2.prod.yaml
+++ b/chart/values.mmli2.prod.yaml
@@ -16,7 +16,7 @@ controller:
 config:
   hostname: "https://mmli.fastapi.mmli2.ncsa.illinois.edu"
   basePath: ""
-  cleandbHostname: "https://fastapi.cleandb.mmli2.ncsa.illinois.edu"
+  cleandbHostname: "https://cleandb-api.platform.moleculemaker.org"
   cleandbBasePath: ""
   signInUrl: "https://auth.platform.moleculemaker.org/oauth2/start?rd=https%3A%2F%2Fcleandb.platform.moleculemaker.org%2Fconfiguration"
   signOutUrl: "https://auth.platform.moleculemaker.org/oauth2/sign_out?rd=https%3A%2F%2Fcleandb.platform.moleculemaker.org%2Fconfiguration"

--- a/src/app/pages/about-page/about-page.component.html
+++ b/src/app/pages/about-page/about-page.component.html
@@ -137,7 +137,7 @@
                     </h5>
 
                     <h5><b class="font-bold">API: </b><a rel="noopener" class="text-[#0080FF] underline" target="_blank"
-                            href="https://fastapi.cleandb.mmli2.ncsa.illinois.edu/api/v1/docs"><i
+                            href="https://cleandb-api.platform.moleculemaker.org/api/v1/docs"><i
                                 class="mx-2 pi pi-external-link"></i>https://fastapi.cleandb.mmli2.ncsa.illinois.edu/api/v1/docs</a>
                     </h5>
                 </main>


### PR DESCRIPTION
## Problem
We are about to publish a manuscript for CLEANDB, but the API URL is still not very user friendly

Add a slightly more user-friendly API URL alias here

Related to https://github.com/moleculemaker/CLEANDB-api/pull/16 

## Approach
* chore: adjust prod configuration to point at this new URL alias - if we had not already configured CORS, this would bypass/alleviate the issue
* wip: an attempt was made to stop the polling from starting multiple times.. but I feel like this is not yet completely working. It's better than it was, but still doesn't feel complete 🤔 

## How to Test
TBD